### PR TITLE
Fix two-column layout shift

### DIFF
--- a/thirdPartyNoneMinified.css
+++ b/thirdPartyNoneMinified.css
@@ -13372,6 +13372,8 @@ to {
     float: left;
     width: 50%;
     min-height: 1px;
+    display: inline-block;
+    vertical-align: top;
 }
 .resume-renderer-two-column:first-child {
     width: 60%;


### PR DESCRIPTION
## Summary
- prevent resume columns from stacking vertically

## Testing
- `tidy -errors index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6851059ebbd483209f8206939e249326